### PR TITLE
#6 Basic state loading in the plugin

### DIFF
--- a/Source/Parameters.h
+++ b/Source/Parameters.h
@@ -17,7 +17,11 @@ struct ParametersStucture
         ProcesorRef.addParameter (mix);
     }
     
-    juce::RangedAudioParameter* delayTime;
-    juce::RangedAudioParameter* delayFeedback;
-    juce::RangedAudioParameter* mix;
+    juce::RangedAudioParameter* delayTime { nullptr };
+    juce::RangedAudioParameter* delayFeedback { nullptr };
+    juce::RangedAudioParameter* mix { nullptr };
+
+private:
+    
+    JUCE_LEAK_DETECTOR (ParametersStucture)
 };

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -155,10 +155,43 @@ juce::AudioProcessorEditor* DelayPluginAudioProcessor::createEditor()
 
 void DelayPluginAudioProcessor::getStateInformation (juce::MemoryBlock& destData)
 {
+    juce::XmlElement stateXML ("Parameters");
+    
+    for (auto& parameter : { params.delayTime, params.delayFeedback, params.mix})
+    {
+        const auto parameterName = parameter->paramID;
+        auto parameterValue = parameter->getValue();
+        const auto range = parameter->getNormalisableRange();
+        parameterValue = range.convertFrom0to1 (parameterValue);
+        
+        const auto parameterValueString = juce::String(parameterValue);
+        
+        auto state = stateXML.createNewChildElement(parameterName);
+        state->setAttribute ("Value" , parameterValueString);
+    }
+    
+    copyXmlToBinary (stateXML, destData);
 }
 
 void DelayPluginAudioProcessor::setStateInformation (const void* data, int sizeInBytes)
 {
+    const auto xmlElement = getXmlFromBinary (data, sizeInBytes);
+        
+    if (xmlElement.get())
+    {
+        auto parameter = xmlElement->getFirstChildElement();
+        auto str = "Value";
+        
+        while (parameter != nullptr)
+        {
+            const auto parameterName = parameter->getTagName();
+            const auto parameterText = parameter->getStringAttribute (str);
+            
+            // Check name for parameters & set value
+            
+            parameter = parameter->getNextElement();
+        }
+    }
 }
 
 juce::AudioProcessor* JUCE_CALLTYPE createPluginFilter()

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -162,9 +162,8 @@ void DelayPluginAudioProcessor::getStateInformation (juce::MemoryBlock& destData
         const auto parameterName = parameter->paramID;
         auto parameterValue = parameter->getValue();
         const auto range = parameter->getNormalisableRange();
-        parameterValue = range.convertFrom0to1 (parameterValue);
         
-        const auto parameterValueString = juce::String(parameterValue);
+        const auto parameterValueString = parameter->getText(parameterValue, 5);
         
         auto state = stateXML.createNewChildElement(parameterName);
         state->setAttribute ("Value" , parameterValueString);
@@ -187,8 +186,17 @@ void DelayPluginAudioProcessor::setStateInformation (const void* data, int sizeI
             const auto parameterName = parameter->getTagName();
             const auto parameterText = parameter->getStringAttribute (str);
             
-            // Check name for parameters & set value
-            
+            for (auto& parameters : { params.delayTime, params.delayFeedback, params.mix})
+            {
+                 if (parameters->getParameterID().equalsIgnoreCase (parameterName))
+                 {
+                     auto realParameterValue = parameters->getValueForText (parameterText);
+                     parameters->setValue (realParameterValue);
+                     
+                     break;
+                 }
+            }
+ 
             parameter = parameter->getNextElement();
         }
     }


### PR DESCRIPTION
I've added very basic state loading code without the AudioValueTreeProcessState, because it's a bit much when compared to just using XML elements to save/ load the state. This will be refactored out into it's own class and needs to be unit test, but is fine for proof of concept. 